### PR TITLE
fix: update github repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Account Abstraction demo app
 
-[The Safe{Core} Account Abstraction SDK](https://github.com/safe-global/account-abstraction-sdk) allows builders to add account abstraction functionality into their apps. This demo is an example on how to use our different packages (Auth Kit, OnRamp Kit & Relay Kit).
+[The Safe{Core} SDK](https://github.com/safe-global/safe-core-sdk) provides a suite of tools to interact with the Safe ecosystem. This demo app is an example of how to use our different packages (Auth Kit, OnRamp Kit & Relay Kit).
 
 See the [Safe{Core} Account Abstraction SDK Docs](https://docs.safe.global/learn/safe-core-account-abstraction-sdk) for more details.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Account Abstraction demo app
 
-[The Safe{Core} SDK](https://github.com/safe-global/safe-core-sdk) provides a suite of tools to interact with the Safe ecosystem. This demo app is an example of how to use our different packages (Auth Kit, OnRamp Kit & Relay Kit).
+[The Safe{Core} SDK](https://github.com/safe-global/safe-core-sdk) allows builders to add account abstraction functionality into their apps. This demo is an example on how to use our different packages (Auth Kit, OnRamp Kit & Relay Kit).
 
 See the [Safe{Core} Account Abstraction SDK Docs](https://docs.safe.global/learn/safe-core-account-abstraction-sdk) for more details.
 

--- a/src/components/safe-core-info/SafeCoreInfo.tsx
+++ b/src/components/safe-core-info/SafeCoreInfo.tsx
@@ -20,7 +20,7 @@ const SafeCoreInfo = () => {
       </Typography>
 
       <Stack direction="row" alignItems="center" spacing={2} marginTop={'8px'} marginLeft={'42px'}>
-        <Link href="https://github.com/safe-global/account-abstraction-sdk" target="_blank">
+        <Link href="https://github.com/safe-global/safe-core-sdk" target="_blank">
           Github
         </Link>
 

--- a/src/pages/AuthKitDemo.tsx
+++ b/src/pages/AuthKitDemo.tsx
@@ -32,7 +32,7 @@ const AuthKitDemo = () => {
 
       <Stack direction="row" alignItems="center" spacing={2}>
         <Link
-          href="https://github.com/safe-global/account-abstraction-sdk/tree/main/packages/auth-kit"
+          href="https://github.com/safe-global/safe-core-sdk/tree/main/packages/auth-kit"
           target="_blank"
         >
           Github

--- a/src/pages/OnRampKitDemo.tsx
+++ b/src/pages/OnRampKitDemo.tsx
@@ -46,7 +46,7 @@ const OnRampKitDemo = () => {
 
       <Stack direction="row" alignItems="center" spacing={2}>
         <Link
-          href="https://github.com/safe-global/account-abstraction-sdk/tree/main/packages/onramp-kit"
+          href="https://github.com/safe-global/safe-core-sdk/tree/main/packages/onramp-kit"
           target="_blank"
         >
           Github

--- a/src/pages/RelayerKitDemo.tsx
+++ b/src/pages/RelayerKitDemo.tsx
@@ -61,7 +61,7 @@ const RelayerKitDemo = () => {
 
       <Stack direction="row" alignItems="center" spacing={2}>
         <Link
-          href="https://github.com/safe-global/account-abstraction-sdk/tree/main/packages/relay-kit"
+          href="https://github.com/safe-global/safe-core-sdk/tree/main/packages/relay-kit"
           target="_blank"
         >
           Github


### PR DESCRIPTION
## What it solves
Resolves #22 

## How this PR fixes it

Replaced old repository `https://github.com/safe-global/account-abstraction-sdk` with the new `https://github.com/safe-global/safe-core-sdk`