### PR TITLE
fix: refresh gelato taskId on logout

### DIFF
--- a/src/store/accountAbstractionContext.tsx
+++ b/src/store/accountAbstractionContext.tsx
@@ -162,6 +162,7 @@ const AccountAbstractionProvider = ({ children }: { children: JSX.Element }) => 
     setWeb3Provider(undefined)
     setSafeSelected('')
     setAuthClient(undefined)
+    setGelatoTaskId(undefined)
   }
 
   // TODO: add disconnect owner wallet logic ?


### PR DESCRIPTION
## What it solves
Resolves #23 


## How this PR fixes it

refresh gelato taskId data on logout.

```
  const logoutWeb3Auth = () => {
    authClient?.signOut()
    setOwnerAddress('')
    setSafes([])
    setChainId(chain.id)
    setWeb3Provider(undefined)
    setSafeSelected('')
    setAuthClient(undefined)
    setGelatoTaskId(undefined) // refresh gelato taskId data
  }
```