### PR TITLE
feat: Safe Selector

### DIFF
--- a/src/components/safe-account/SafeAccount.tsx
+++ b/src/components/safe-account/SafeAccount.tsx
@@ -32,7 +32,11 @@ function SafeAccount(props: BoxProps) {
           onChange={(event: SelectChangeEvent) => setSafeSelected(event.target.value as string)}
         >
           {safes.map((safeAddress) => (
-            <MenuItem value={safeAddress} onClick={() => setSafeSelected(safeAddress)}>
+            <MenuItem
+              key={safeAddress}
+              value={safeAddress}
+              onClick={() => setSafeSelected(safeAddress)}
+            >
               <div
                 style={{
                   display: 'flex',

--- a/src/components/safe-account/SafeAccount.tsx
+++ b/src/components/safe-account/SafeAccount.tsx
@@ -20,35 +20,39 @@ function SafeAccount(props: BoxProps) {
       <Typography fontSize="14px" marginTop="8px" marginBottom="32px">
         Your Safe account (Smart Contract) holds and protects your assets.
       </Typography>
-      <FormControl fullWidth sx={{ marginBottom: '20px' }}>
-        <InputLabel id="switch-address-selector-label">Select Safe</InputLabel>
-        <Select
-          color="success"
-          aria-label="safe address selector"
-          id="switch-address-selector"
-          labelId="switch-address-selector-label"
-          label="Select Safe"
-          value={safeSelected}
-          onChange={(event: SelectChangeEvent) => setSafeSelected(event.target.value as string)}
-        >
-          {safes.map((safeAddress) => (
-            <MenuItem
-              key={safeAddress}
-              value={safeAddress}
-              onClick={() => setSafeSelected(safeAddress)}
-            >
-              <div
-                style={{
-                  display: 'flex',
-                  justifyContent: 'center'
-                }}
+
+      {!!safes && safes.length > 1 && (
+        <FormControl fullWidth sx={{ marginBottom: '20px' }}>
+          <InputLabel id="switch-address-selector-label">Select Safe</InputLabel>
+          <Select
+            color="success"
+            aria-label="safe address selector"
+            id="switch-address-selector"
+            labelId="switch-address-selector-label"
+            label="Select Safe"
+            value={safeSelected}
+            onChange={(event: SelectChangeEvent) => setSafeSelected(event.target.value as string)}
+          >
+            {safes.map((safeAddress) => (
+              <MenuItem
+                key={safeAddress}
+                value={safeAddress}
+                onClick={() => setSafeSelected(safeAddress)}
               >
-                <AddressLabel address={safeAddress} />
-              </div>
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'center'
+                  }}
+                >
+                  <AddressLabel address={safeAddress} />
+                </div>
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      )}
+
       {/* Safe Info */}
       {safeSelected && <SafeInfo safeAddress={safeSelected} chainId={chainId} />}
     </ConnectedContainer>

--- a/src/components/safe-account/SafeAccount.tsx
+++ b/src/components/safe-account/SafeAccount.tsx
@@ -1,12 +1,17 @@
 import Typography from '@mui/material/Typography'
 import SafeInfo from 'src/components/safe-info/SafeInfo'
+import Select, { SelectChangeEvent } from '@mui/material/Select'
+import MenuItem from '@mui/material/MenuItem'
 import { BoxProps } from '@mui/material/Box'
+import FormControl from '@mui/material/FormControl'
+import AddressLabel from 'src/components/address-label/AddressLabel'
 
 import { ConnectedContainer } from 'src/components/styles'
 import { useAccountAbstraction } from 'src/store/accountAbstractionContext'
+import { InputLabel } from '@mui/material'
 
 function SafeAccount(props: BoxProps) {
-  const { safeSelected, chainId } = useAccountAbstraction()
+  const { safeSelected, chainId, safes, setSafeSelected } = useAccountAbstraction()
 
   return (
     <ConnectedContainer {...props}>
@@ -15,7 +20,31 @@ function SafeAccount(props: BoxProps) {
       <Typography fontSize="14px" marginTop="8px" marginBottom="32px">
         Your Safe account (Smart Contract) holds and protects your assets.
       </Typography>
-
+      <FormControl fullWidth sx={{ marginBottom: '20px' }}>
+        <InputLabel id="switch-address-selector-label">Select Safe</InputLabel>
+        <Select
+          color="success"
+          aria-label="safe address selector"
+          id="switch-address-selector"
+          labelId="switch-address-selector-label"
+          label="Select Safe"
+          value={safeSelected}
+          onChange={(event: SelectChangeEvent) => setSafeSelected(event.target.value as string)}
+        >
+          {safes.map((safeAddress) => (
+            <MenuItem value={safeAddress} onClick={() => setSafeSelected(safeAddress)}>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'center'
+                }}
+              >
+                <AddressLabel address={safeAddress} />
+              </div>
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
       {/* Safe Info */}
       {safeSelected && <SafeInfo safeAddress={safeSelected} chainId={chainId} />}
     </ConnectedContainer>

--- a/src/pages/OnRampKitDemo.tsx
+++ b/src/pages/OnRampKitDemo.tsx
@@ -69,8 +69,9 @@ const OnRampKitDemo = ({ setStep }: OnRampKitDemoProps) => {
       </Typography>
 
       <Typography marginTop="16px">
-        Allow users to buy cryptocurrencies using a credit card and other payment options directly
-        within your app. Click on "Buy USDC" to on-ramp funds to your Safe using the Stripe widget!
+        {tabsValue === 0
+          ? 'With Monerium you can connect your web3 wallet to any euro bank account with your personal IBAN, directly transferable between your wallet and bank accounts.'
+          : 'Allow users to buy cryptocurrencies using a credit card and other payment options directly within your app. Click on "Buy USDC" to on-ramp funds to your Safe using the Stripe widget!'}
       </Typography>
 
       <Typography marginTop="24px" marginBottom="8px">

--- a/src/pages/OnRampKitDemo.tsx
+++ b/src/pages/OnRampKitDemo.tsx
@@ -70,7 +70,7 @@ const OnRampKitDemo = ({ setStep }: OnRampKitDemoProps) => {
 
       <Typography marginTop="16px">
         {tabsValue === 0
-          ? 'With Monerium you can connect your web3 wallet to any euro bank account with your personal IBAN, directly transferable between your wallet and bank accounts.'
+          ? 'Monerium gives you a personal IBAN for your web3 wallet to send and receive Euros between your wallet and bank accounts in seconds.'
           : 'Allow users to buy cryptocurrencies using a credit card and other payment options directly within your app. Click on "Buy USDC" to on-ramp funds to your Safe using the Stripe widget!'}
       </Typography>
 

--- a/src/store/accountAbstractionContext.tsx
+++ b/src/store/accountAbstractionContext.tsx
@@ -71,6 +71,7 @@ const useAccountAbstraction = () => {
 }
 
 const MONERIUM_TOKEN = 'monerium_token'
+const MONERIUM_SELECTED_SAFE = 'monerium_safe_selected'
 
 const AccountAbstractionProvider = ({ children }: { children: JSX.Element }) => {
   // owner address from the email  (provided by web3Auth)
@@ -236,6 +237,8 @@ const AccountAbstractionProvider = ({ children }: { children: JSX.Element }) => 
     async (authCode?: string, refreshToken?: string) => {
       if (!moneriumPack) return
 
+      localStorage.setItem(MONERIUM_SELECTED_SAFE, safeSelected)
+
       const moneriumClient = await moneriumPack.open({
         redirectUrl: process.env.REACT_APP_MONERIUM_REDIRECT_URL,
         authCode,
@@ -281,8 +284,11 @@ const AccountAbstractionProvider = ({ children }: { children: JSX.Element }) => 
         await safeAccountAbstraction.init({ relayPack })
 
         const hasSafes = safes.length > 0
+        const storedSafe = localStorage.getItem(MONERIUM_SELECTED_SAFE) || undefined
 
-        const safeSelected = hasSafes ? safes[0] : await safeAccountAbstraction.getSafeAddress()
+        const safeSelected = hasSafes
+          ? storedSafe || safes[0]
+          : await safeAccountAbstraction.getSafeAddress()
 
         setSafeSelected(safeSelected)
       }


### PR DESCRIPTION
I found a bug when having multiple safes to pick from; the Monerium flow would redirect back, causing the safeSdk to initialize with another address then the Monerium flow was initiated with, causing it to stop on `moneriumPack.open(...)`.

Solved by adding the selected Safe to localStorage, to be picked up when redirected back.


I included the changes from #35 