### PR TITLE
Migrate Monerium to Sepolia

### DIFF
--- a/src/components/monerium/MoneriumChainWarning.tsx
+++ b/src/components/monerium/MoneriumChainWarning.tsx
@@ -8,7 +8,7 @@ type MoneriumChainWarningProps = {
 function MoneriumChainWarning({ onUpdateChain }: MoneriumChainWarningProps) {
   return (
     <Typography fontSize="14px" marginTop="16px" marginBottom="32px">
-      The Monerium payments are only enabled in Goerli chain.{' '}
+      The Monerium payments are only enabled in Sepolia chain.{' '}
       <Link href="#" onClick={onUpdateChain}>
         Update the chosen chain
       </Link>{' '}

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -16,22 +16,6 @@ export const gnosisChain: Chain = {
   ]
 }
 
-export const goerliChain: Chain = {
-  id: '0x5',
-  token: 'gETH',
-  label: 'Görli',
-  shortName: 'gor',
-  rpcUrl: 'https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
-  blockExplorerUrl: 'https://goerli.etherscan.io',
-  color: '#fbc02d',
-  transactionServiceUrl: 'https://safe-transaction-goerli.safe.global',
-  isStripePaymentsEnabled: false,
-  isMoneriumPaymentsEnabled: true,
-  supportedErc20Tokens: [
-    '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6' // WETH
-  ]
-}
-
 export const mainnetChain: Chain = {
   id: '0x1',
   token: 'ETH',
@@ -89,14 +73,13 @@ export const sepoliaChain: Chain = {
   blockExplorerUrl: 'https://sepolia.polygonscan.com',
   color: '#AA36A7',
   isStripePaymentsEnabled: false,
-  isMoneriumPaymentsEnabled: false,
+  isMoneriumPaymentsEnabled: true,
   faucetUrl: 'https://sepoliafaucet.com/',
   supportedErc20Tokens: ['0x8267cF9254734C6Eb452a7bb9AAF97B392258b21']
 }
 
 const chains: Chain[] = [
   gnosisChain,
-  goerliChain,
   mainnetChain,
   mumbaiChain,
   polygonChain,

--- a/src/models/chain.ts
+++ b/src/models/chain.ts
@@ -9,7 +9,7 @@ type Chain = {
   blockExplorerUrl: string
   transactionServiceUrl?: string
   isStripePaymentsEnabled: boolean // only available in Mumbai chain
-  isMoneriumPaymentsEnabled: boolean // only available in Goerli chain
+  isMoneriumPaymentsEnabled: boolean // only available in Sepolia chain
   faucetUrl?: string
   supportedErc20Tokens?: string[] // erc20 token contract addresses that can be used to pay transaction fees
 }

--- a/src/pages/Intro.tsx
+++ b/src/pages/Intro.tsx
@@ -1,9 +1,9 @@
-import Button from '@mui/material/Button'
-import Typography from '@mui/material/Typography'
-import Box from '@mui/material/Box'
-import Divider from '@mui/material/Divider'
 import styled from '@emotion/styled'
 import { Theme } from '@mui/material'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Divider from '@mui/material/Divider'
+import Typography from '@mui/material/Typography'
 
 import safeLogo from 'src/assets/safe-logo.svg'
 import ChainSelector from 'src/components/chain-selector/ChainSelector'
@@ -69,7 +69,7 @@ const Intro = ({ setStep }: IntroProps) => {
       </Typography>
 
       <Typography>
-        Please note: the Onramp kit will only work in the EU on Görli and in the US on Mumbai test chains.
+        Please note: the Onramp kit will only work in the EU on Sepolia and in the US on Mumbai test chains.
       </Typography>
 
       <Box display="flex" gap={2} marginTop="32px" alignItems="center">

--- a/src/pages/OnRampKitDemo.tsx
+++ b/src/pages/OnRampKitDemo.tsx
@@ -1,29 +1,29 @@
-import { useEffect, useState } from 'react'
 import WalletIcon from '@mui/icons-material/AccountBalanceWalletRounded'
-import LoginIcon from '@mui/icons-material/Login'
 import CloseIcon from '@mui/icons-material/CloseRounded'
-import Tab from '@mui/material/Tab'
-import Tabs from '@mui/material/Tabs'
+import LoginIcon from '@mui/icons-material/Login'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Divider from '@mui/material/Divider'
 import IconButton from '@mui/material/IconButton'
 import Link from '@mui/material/Link'
 import Stack from '@mui/material/Stack'
+import Tab from '@mui/material/Tab'
+import Tabs from '@mui/material/Tabs'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
+import { useEffect, useState } from 'react'
 
 import { useAccountAbstraction } from 'src/store/accountAbstractionContext'
-import { MONERIUM_SNIPPET, STRIPE_SNIPPET } from 'src/utils/snippets'
 import isContractAddress from 'src/utils/isContractAddress'
+import { MONERIUM_SNIPPET, STRIPE_SNIPPET } from 'src/utils/snippets'
 
-import Code from 'src/components/code/Code'
 import AuthenticateMessage from 'src/components/authenticate-message/AuthenticateMessage'
-import { ConnectedContainer } from 'src/components/styles'
-import SafeAccount from 'src/components/safe-account/SafeAccount'
-import MoneriumDeploySafeAccount from 'src/components/monerium/MoneriumDeploySafeAccount'
+import Code from 'src/components/code/Code'
 import MoneriumChainWarning from 'src/components/monerium/MoneriumChainWarning'
+import MoneriumDeploySafeAccount from 'src/components/monerium/MoneriumDeploySafeAccount'
 import MoneriumInfo from 'src/components/monerium/MoneriumInfo'
+import SafeAccount from 'src/components/safe-account/SafeAccount'
+import { ConnectedContainer } from 'src/components/styles'
 
 type OnRampKitDemoProps = {
   setStep: (newStep: number) => void
@@ -141,7 +141,7 @@ const OnRampKitDemo = ({ setStep }: OnRampKitDemoProps) => {
                         disabled={!chain?.isMoneriumPaymentsEnabled || !isSafeDeployed}
                       >
                         Login
-                        {!chain?.isMoneriumPaymentsEnabled && ' (only on Goerli chain)'}
+                        {!chain?.isMoneriumPaymentsEnabled && ' (only on Sepolia chain)'}
                       </Button>
                     </Tooltip>
                   </>


### PR DESCRIPTION
# DO NOT MERGE THIS PR

## Context
Monerium will at some point deprecate Goerli support in favour of Sepolia but they haven't done it yet.

This PR:
- Replaces Goerli references with Sepolia.

